### PR TITLE
eval: add strains

### DIFF
--- a/eval/locations.go
+++ b/eval/locations.go
@@ -10,13 +10,13 @@ import (
 
 // LocationsResponse contains all data needed to verify the locations sheet.
 type LocationsResponse struct {
-	Create LocationRow `json:"create"` // first row
-	Update LocationRow `json:"update"` // second row
-	Get    LocationRow `json:"get"`    // third row
+	Create EvalRow `json:"create"` // first row
+	Update EvalRow `json:"update"` // second row
+	Get    EvalRow `json:"get"`    // third row
 }
 
-// LocationRow represents a row in the spreadsheet for location.
-type LocationRow struct {
+// EvalRow represents a row in the spreadsheet for evaluations.
+type EvalRow struct {
 	Code           int    `json:"code"`
 	License        string `json:"license"`
 	Id             int    `json:"id"`
@@ -70,10 +70,10 @@ func (e *EvalMetrc) Locations(license string) (LocationsResponse, error) {
 
 // CreateLocation creates a new location and returns its information.
 // It corresponds to Step 1 in the Locations tab of the Metrc Evaluation spreadsheet.
-func (e *EvalMetrc) CreateLocation(license string, name string) (LocationRow, error) {
+func (e *EvalMetrc) CreateLocation(license string, name string) (EvalRow, error) {
 	gotLocs, err := e.Metrc.GetLocationsActive(&license)
 	if err != nil {
-		return LocationRow{}, fmt.Errorf("could not initially get active: %s", err)
+		return EvalRow{}, fmt.Errorf("could not initially get active: %s", err)
 	}
 
 	// name := "Metrc Eval Location"
@@ -86,7 +86,7 @@ func (e *EvalMetrc) CreateLocation(license string, name string) (LocationRow, er
 
 	_, err = e.Metrc.CreateLocations(inputLocs, &license)
 	if err != nil {
-		return LocationRow{}, fmt.Errorf("could not create initial location: %s", err)
+		return EvalRow{}, fmt.Errorf("could not create initial location: %s", err)
 	}
 
 	gotLocs, err = e.Metrc.GetLocationsActive(&license)
@@ -101,7 +101,7 @@ func (e *EvalMetrc) CreateLocation(license string, name string) (LocationRow, er
 	}
 
 	if !foundLocName {
-		return LocationRow{}, fmt.Errorf("could not get loc with matching name: %s", err)
+		return EvalRow{}, fmt.Errorf("could not get loc with matching name: %s", err)
 	}
 
 	endpoint := "locations/v1/create"
@@ -110,11 +110,11 @@ func (e *EvalMetrc) CreateLocation(license string, name string) (LocationRow, er
 
 	resp, err := json.MarshalIndent(inputLocs, "", "\t")
 	if err != nil {
-		return LocationRow{}, fmt.Errorf("could not marshal input body")
+		return EvalRow{}, fmt.Errorf("could not marshal input body")
 	}
 	response := string(resp)
 
-	return LocationRow{
+	return EvalRow{
 		Code:           200,
 		License:        license,
 		Id:             locId,
@@ -126,7 +126,7 @@ func (e *EvalMetrc) CreateLocation(license string, name string) (LocationRow, er
 
 // UpdateLocationResponse displays the information to verify updating a location.
 // This corresponds to Step 2 in the Locations tab of the Metrc Evaluation spreadsheet.
-func (e *EvalMetrc) UpdateLocation(license string, name string, id int) (LocationRow, error) {
+func (e *EvalMetrc) UpdateLocation(license string, name string, id int) (EvalRow, error) {
 	// name := "Metrc Eval Location Updated"
 	updateLocs := []metrc.LocationPost{
 		{
@@ -138,7 +138,7 @@ func (e *EvalMetrc) UpdateLocation(license string, name string, id int) (Locatio
 
 	_, err := e.Metrc.UpdateLocations(updateLocs, &license)
 	if err != nil {
-		return LocationRow{}, fmt.Errorf("could not update locations: %s", err)
+		return EvalRow{}, fmt.Errorf("could not update locations: %s", err)
 	}
 
 	endpoint := "locations/v1/update"
@@ -146,11 +146,11 @@ func (e *EvalMetrc) UpdateLocation(license string, name string, id int) (Locatio
 	request := fmt.Sprintf("%s/%s%s", metrcUrl, endpoint, queryParam)
 	resp, err := json.MarshalIndent(updateLocs, "", "\t")
 	if err != nil {
-		return LocationRow{}, fmt.Errorf("could not marshal update body: %s", err)
+		return EvalRow{}, fmt.Errorf("could not marshal update body: %s", err)
 	}
 	response := string(resp)
 
-	return LocationRow{
+	return EvalRow{
 		Code:           200,
 		License:        license,
 		Id:             id,
@@ -162,10 +162,10 @@ func (e *EvalMetrc) UpdateLocation(license string, name string, id int) (Locatio
 
 // GetLocationResponse displays the information to verify getting the final location.
 // This corresponds to Step 3 in the Locations tab of the Metrc Evaluation spreadsheet.
-func (e *EvalMetrc) GetLocation(license string, name string, id int) (LocationRow, error) {
+func (e *EvalMetrc) GetLocation(license string, name string, id int) (EvalRow, error) {
 	gotLoc, err := e.Metrc.GetLocationsById(id, &license)
 	if err != nil {
-		return LocationRow{}, fmt.Errorf("could not get locs by id: %s", err)
+		return EvalRow{}, fmt.Errorf("could not get locs by id: %s", err)
 	}
 
 	endpoint := fmt.Sprintf("locations/v1/%d", id)
@@ -174,11 +174,11 @@ func (e *EvalMetrc) GetLocation(license string, name string, id int) (LocationRo
 
 	resp, err := json.MarshalIndent(gotLoc, "", "\t")
 	if err != nil {
-		return LocationRow{}, fmt.Errorf("could not marshal got resp body: %s", err)
+		return EvalRow{}, fmt.Errorf("could not marshal got resp body: %s", err)
 	}
 	response := string(resp)
 
-	return LocationRow{
+	return EvalRow{
 		Code:           200,
 		License:        license,
 		Id:             id,

--- a/eval/strains.go
+++ b/eval/strains.go
@@ -1,0 +1,132 @@
+package eval
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/hash-labs/metrc"
+)
+
+// StrainsResponse contains all data needed to verify the `strains` sheet.
+type StrainsResponse struct {
+	Create EvalRow `json:"create"` // first row
+	Get    EvalRow `json:"get"`    // second row
+}
+
+func (e *EvalMetrc) Strains(license string) (StrainsResponse, error) {
+	ts := time.Now().Format("2021.01.01 12:00:00")
+	name := fmt.Sprintf("Metrc Strain Name %s", ts)
+
+	cs, err := e.CreateStrain(license, name)
+	if err != nil {
+		return StrainsResponse{}, fmt.Errorf("could not create strain: %s", err)
+	}
+
+	id := cs.Id
+	gs, err := e.GetStrain(license, name, id)
+	if err != nil {
+		return StrainsResponse{}, fmt.Errorf("could not get strain: %s", err)
+	}
+
+	sr := StrainsResponse{
+		Create: cs,
+		Get:    gs,
+	}
+
+	// Comment deletion out for production / persistent results.
+	// TODO: Make deletion configurable between testing and deploy.
+	_, err = e.Metrc.DeleteStrainById(id, &license)
+	if err != nil {
+		return StrainsResponse{}, fmt.Errorf("could not delete strain: %s", err)
+	}
+	return sr, nil
+}
+
+// CreateStrain creates a new strain and returns its information.
+// It corresponds to Step 1 in the Strains tab of the Metrc Evaluation spreadsheet.
+func (e *EvalMetrc) CreateStrain(license string, name string) (EvalRow, error) {
+	// TODO: Understand why ThcLevel and CbdLevel aren't persisted.
+	inputStrains := []metrc.Strain{
+		{
+			Name:             name,
+			TestingStatus:    "None",
+			ThcLevel:         .185,
+			CbdLevel:         .275,
+			IndicaPercentage: 25.0,
+			SativaPercentage: 75.0,
+		},
+	}
+
+	_, err := e.Metrc.CreateStrains(inputStrains, &license)
+	if err != nil {
+		return EvalRow{}, fmt.Errorf("could not create strains: %s", err)
+	}
+
+	gotStrains, err := e.Metrc.GetStrainsActive(&license)
+	if err != nil {
+		return EvalRow{}, fmt.Errorf("could not get active strains: %s", err)
+	}
+
+	var foundStrainName bool
+	var gotStrain metrc.Strain
+	for _, strain := range gotStrains {
+		if strain.Name == name {
+			foundStrainName = true
+			gotStrain = strain
+			break
+		}
+	}
+
+	if !foundStrainName {
+		return EvalRow{}, fmt.Errorf("could not get strain with matching name: %s", err)
+	}
+
+	endpoint := "strains/v1/create"
+	queryParam := fmt.Sprintf("?licenseNumber=%s", license)
+	request := fmt.Sprintf("%s/%s%s", metrcUrl, endpoint, queryParam)
+
+	bodyBytes, err := json.MarshalIndent(gotStrain, "", "\t")
+	if err != nil {
+		return EvalRow{}, fmt.Errorf("could not marshal input body")
+	}
+	body := string(bodyBytes)
+
+	return EvalRow{
+		Code:           200,
+		License:        license,
+		Id:             gotStrain.Id,
+		Name:           name,
+		Request:        request,
+		BodyOrResponse: body,
+	}, nil
+}
+
+// GetStrain gets the created strain and returns its information.
+// It corresponds to Step 2 in the Strains tab of the Metrc Evaluation spreadsheet.
+func (e *EvalMetrc) GetStrain(license string, name string, id int) (EvalRow, error) {
+	// TODO: Implement
+	gotStrain, err := e.Metrc.GetStrainsById(id, &license)
+	if err != nil {
+		return EvalRow{}, fmt.Errorf("could not get strain by id: %s", err)
+	}
+
+	endpoint := fmt.Sprintf("strains/v1/%d", id)
+	queryParam := fmt.Sprintf("?licenseNumber=%s", license)
+	request := fmt.Sprintf("%s/%s%s", metrcUrl, endpoint, queryParam)
+
+	resp, err := json.MarshalIndent(gotStrain, "", "\t")
+	if err != nil {
+		return EvalRow{}, fmt.Errorf("could not marshal got resp body: %s", err)
+	}
+	response := string(resp)
+
+	return EvalRow{
+		Code:           200,
+		License:        license,
+		Id:             id,
+		Name:           name,
+		Request:        request,
+		BodyOrResponse: response,
+	}, nil
+}

--- a/main.go
+++ b/main.go
@@ -16,4 +16,11 @@ func main() {
 		panic(err)
 	}
 	fmt.Printf("%#v\n", lr)
+
+	// Call Strains endpoints
+	sr, err := e.Strains(licenseNumber)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%#v\n", sr)
 }


### PR DESCRIPTION
This PR adds the necessary logic to populate `strains` in the spreadsheet. It also modifies some variable names for easier repurposing.